### PR TITLE
Fix kafka_fdw unexpected errors

### DIFF
--- a/src/kafka_fdw.h
+++ b/src/kafka_fdw.h
@@ -246,7 +246,7 @@ typedef struct KafkaFdwModifyState
     List *               partition_list;     /* integer list of partitions */
     StringInfoData       attname_buf;        /* buffer holding attribute names for json format */
     char **              attnames;           /* pointer into attname_buf */
-
+    int32                partition_cnt;
 } KafkaFdwModifyState;
 /* connection.c */
 void KafkaFdwGetConnection(KafkaOptions *k_options,

--- a/src/option.c
+++ b/src/option.c
@@ -487,6 +487,24 @@ get_kafka_fdw_attribute_options(Oid relid, KafkaOptions *kafka_options)
         }
     }
 
+	if (rel->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
+	{
+		if (kafka_options->partition_attnum == -1)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FDW_ERROR),
+					errmsg("missing column definition with option (partition 'true')"),
+					errhint("Specify a column and set its option to (partition 'true')")));
+		}
+		if (kafka_options->offset_attnum == -1)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FDW_ERROR),
+					errmsg("missing column definition with option (offset 'true')"),
+					errhint("Specify a column and set its option to (offset 'true')")));
+		}
+	}
+
     /* calculate number of parsable columns */
 
     if (kafka_options->partition_attnum != -1)

--- a/test/expected/cbdb_test.out
+++ b/test/expected/cbdb_test.out
@@ -1,0 +1,54 @@
+\i test/sql/setup.inc
+\set ECHO none
+-- This file contains extra tests for Apache Cloudberry
+-- 1.column options 'partition' and 'offset ' are essential
+CREATE FOREIGN TABLE invalid_kafka_table (
+    some_int int OPTIONS (json 'int_val'),
+    some_text text OPTIONS (json 'text_val'),
+    some_date date OPTIONS (json 'date_val'),
+    some_time timestamp OPTIONS (json 'time_val')
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_cloudberry', batch_size '30', buffer_delay '500');
+select * from invalid_kafka_table;
+ERROR:  missing column definition with option (partition 'true')
+HINT:  Specify a column and set its option to (partition 'true')
+drop foreign table invalid_kafka_table;
+CREATE FOREIGN TABLE invalid_kafka_table (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'false'),
+    some_int int OPTIONS (json 'int_val'),
+    some_text text OPTIONS (json 'text_val'),
+    some_date date OPTIONS (json 'date_val'),
+    some_time timestamp OPTIONS (json 'time_val')
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_cloudberry', batch_size '30', buffer_delay '500');
+select * from invalid_kafka_table;
+ERROR:  missing column definition with option (offset 'true')
+HINT:  Specify a column and set its option to (offset 'true')
+drop foreign table invalid_kafka_table;
+-- 2. insert into a non-exist partition
+CREATE FOREIGN TABLE normal_kafka_table (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int OPTIONS (json 'int_val'),
+    some_text text OPTIONS (json 'text_val'),
+    some_date date OPTIONS (json 'date_val'),
+    some_time timestamp OPTIONS (json 'time_val')
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_cloudberry', batch_size '30', buffer_delay '500');
+-- invalid partition
+insert into normal_kafka_table(part, some_int, some_text, some_date, some_time) values (10, 1, 'jack', now(), now());
+ERROR:  invalid partition number 10  (seg2 172.17.0.3:7004 pid=24750)
+DETAIL:  Topic "contrib_regress_cloudberry" has only 3 partitions (0-2).
+-- valid partition
+insert into normal_kafka_table(part, some_int, some_text, some_date, some_time) values (0, 1, 'jack', now(), now());
+select count(*) from normal_kafka_table;
+ count 
+-------
+     2
+(1 row)
+
+drop foreign table normal_kafka_table;

--- a/test/expected/kafka_test.out
+++ b/test/expected/kafka_test.out
@@ -243,8 +243,8 @@ SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs = (SELECT 1) 
 (11 rows)
 
 SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs = 0 AND part = (SELECT 1)');
-                                  explain_invariant                                  
--------------------------------------------------------------------------------------
+                                   explain_invariant                                   
+---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
@@ -259,8 +259,8 @@ SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs = 0 AND part 
 (11 rows)
 
 SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs < (SELECT 1) AND part = 0');
-                                  explain_invariant                                  
--------------------------------------------------------------------------------------
+                                   explain_invariant                                   
+---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
@@ -275,8 +275,8 @@ SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs < (SELECT 1) 
 (11 rows)
 
 SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs <= (SELECT 1) AND part = 0');
-                                  explain_invariant                                  
--------------------------------------------------------------------------------------
+                                   explain_invariant                                   
+---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
@@ -291,8 +291,8 @@ SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs <= (SELECT 1)
 (11 rows)
 
 SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs = 0 AND part < (SELECT 1)');
-                                  explain_invariant                                  
--------------------------------------------------------------------------------------
+                                   explain_invariant                                   
+---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
@@ -307,8 +307,8 @@ SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs = 0 AND part 
 (11 rows)
 
 SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs = 0 AND part <= (SELECT 1)');
-                                  explain_invariant                                  
--------------------------------------------------------------------------------------
+                                   explain_invariant                                   
+---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)

--- a/test/init_kafka.sh
+++ b/test/init_kafka.sh
@@ -5,8 +5,8 @@ KAFKA_BIN_DIR=~/kafka
 : ${KAFKA_PRODUCER:="${KAFKA_BIN_DIR}/bin/kafka-console-producer.sh"}
 : ${KAFKA_TOPICS:="${KAFKA_BIN_DIR}/bin/kafka-topics.sh"}
 
-topics=( contrib_regress4 contrib_regress contrib_regress_prod contrib_regress_prod_json contrib_regress_junk contrib_regress_json contrib_regress_json_junk )
-partitions=( 4 1 4 4 1 1 1 )
+topics=( contrib_regress4 contrib_regress contrib_regress_prod contrib_regress_prod_json contrib_regress_junk contrib_regress_json contrib_regress_json_junk contrib_regress_cloudberry)
+partitions=( 4 1 4 4 1 1 1 3 )
 
 if [[ -n "${PG_CONFIG}" ]]; then
 	BIN=$(${PG_CONFIG} --bindir)
@@ -74,4 +74,8 @@ $kafka_cmd contrib_regress_json_junk <<-EOF
 {"int_val" : 999841, "text_val" : "empty time" , "date_val" : "2015-01-12", "time_val" : ""}
 {"int_val" : 999851, "text_val" : "correct line null time", "date_val" : "2015-01-12", "time_val" : null}
 {"int_val" : 999871, "invalid json no time" : "invalid json", "date_val" : "2015-01-12", "time_val" : }
+EOF
+
+$kafka_cmd contrib_regress_cloudberry <<-EOF
+{"int_val" : 8893920, "text_val" : "correct line", "date_val" : "2015-01-12", "time_val" : "2015-01-12T13:42:21"}
 EOF

--- a/test/run_kafka.sh
+++ b/test/run_kafka.sh
@@ -18,7 +18,9 @@ DIST=$(cat /etc/os-release | grep ^ID= | sed s/ID=//)
 echo
 
 # # Download Apache Kafka
-wget https://downloads.apache.org/kafka/${KAFKA_VERSION}/${KAFKA_ARCHIVE}
+if [ ! -f "${KAFKA_ARCHIVE}" ]; then
+    wget https://downloads.apache.org/kafka/${KAFKA_VERSION}/${KAFKA_ARCHIVE}
+fi
 tar -xzf ${KAFKA_ARCHIVE} -C ${KAFKA_BIN_DIR} --strip-components=1
 export PATH="${KAFKA_BIN_DIR}/bin/:$PATH"
 

--- a/test/sql/cbdb_test.sql
+++ b/test/sql/cbdb_test.sql
@@ -1,0 +1,53 @@
+\i test/sql/setup.inc
+
+-- This file contains extra tests for Apache Cloudberry
+
+-- 1.column options 'partition' and 'offset ' are essential
+CREATE FOREIGN TABLE invalid_kafka_table (
+    some_int int OPTIONS (json 'int_val'),
+    some_text text OPTIONS (json 'text_val'),
+    some_date date OPTIONS (json 'date_val'),
+    some_time timestamp OPTIONS (json 'time_val')
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_cloudberry', batch_size '30', buffer_delay '500');
+
+select * from invalid_kafka_table;
+
+drop foreign table invalid_kafka_table;
+
+CREATE FOREIGN TABLE invalid_kafka_table (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'false'),
+    some_int int OPTIONS (json 'int_val'),
+    some_text text OPTIONS (json 'text_val'),
+    some_date date OPTIONS (json 'date_val'),
+    some_time timestamp OPTIONS (json 'time_val')
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_cloudberry', batch_size '30', buffer_delay '500');
+
+select * from invalid_kafka_table;
+drop foreign table invalid_kafka_table;
+
+-- 2. insert into a non-exist partition
+CREATE FOREIGN TABLE normal_kafka_table (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int OPTIONS (json 'int_val'),
+    some_text text OPTIONS (json 'text_val'),
+    some_date date OPTIONS (json 'date_val'),
+    some_time timestamp OPTIONS (json 'time_val')
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_cloudberry', batch_size '30', buffer_delay '500');
+
+-- invalid partition
+insert into normal_kafka_table(part, some_int, some_text, some_date, some_time) values (10, 1, 'jack', now(), now());
+
+-- valid partition
+insert into normal_kafka_table(part, some_int, some_text, some_date, some_time) values (0, 1, 'jack', now(), now());
+
+select count(*) from normal_kafka_table;
+
+drop foreign table normal_kafka_table;


### PR DESCRIPTION
1. The foreign table must have two meta columns with option (partition 'true') and (offset 'true').
2. Cannot insert with an invalid partition number.