### PR TITLE
Support SASL authentication in foreign insert

### DIFF
--- a/src/kafka_fdw.c
+++ b/src/kafka_fdw.c
@@ -1354,6 +1354,34 @@ kafkaBeginForeignModify(ModifyTableState *mtstate,
     rd_kafka_conf_set(conf, "retry.backoff.ms", "500", NULL, 0);
     */
 
+	/* group id */
+	if (kafka_options.group_id != NULL)
+	{
+		if (rd_kafka_conf_set(conf, "group.id", kafka_options.group_id,
+								errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+			elog(ERROR, "%s\n", errstr);
+	}
+
+	/* security options */
+	if (kafka_options.security_protocol != NULL)
+	{
+		if (rd_kafka_conf_set(conf, "security.protocol", kafka_options.security_protocol,
+								errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+			elog(ERROR, "%s\n", errstr);
+
+		if (rd_kafka_conf_set(conf, "sasl.mechanisms", kafka_options.sasl_mechanisms,
+								errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+			elog(ERROR, "%s\n", errstr);
+
+		if (rd_kafka_conf_set(conf, "sasl.username", kafka_options.sasl_username,
+								errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+			elog(ERROR, "%s\n", errstr);
+
+		if (rd_kafka_conf_set(conf, "sasl.password", kafka_options.sasl_password,
+								errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+			elog(ERROR, "%s\n", errstr);
+	}
+
     /*
      * Create producer instance.
      *

--- a/test/expected/auth/auth_basic.out
+++ b/test/expected/auth/auth_basic.out
@@ -27,3 +27,13 @@ select * from auth_basic_tab1;
     0 |    0 |  8893920 | correct line | 01-12-2015 | Mon Jan 12 13:42:21 2015
 (1 row)
 
+-- insert is also supported
+insert into auth_basic_tab1 (some_int, some_text, some_date, some_time) values
+(10, 'test1', '2024-01-01', '2024-01-01 10:00:00'),
+(20, 'test2', '2024-02-02', '2024-02-02 11:00:00');
+select count(*) from auth_basic_tab1;
+ count 
+-------
+     3
+(1 row)
+

--- a/test/sql/auth/auth_basic.sql
+++ b/test/sql/auth/auth_basic.sql
@@ -26,3 +26,10 @@ alter server kafka_auth_server options (set sasl_username 'kafka_fdw_user');
 alter server kafka_auth_server options (set sasl_password 'kafka_fdw_pass');
 
 select * from auth_basic_tab1;
+
+-- insert is also supported
+insert into auth_basic_tab1 (some_int, some_text, some_date, some_time) values
+(10, 'test1', '2024-01-01', '2024-01-01 10:00:00'),
+(20, 'test2', '2024-02-02', '2024-02-02 11:00:00');
+
+select count(*) from auth_basic_tab1;


### PR DESCRIPTION
We have already support SASL authentication in foreign scan, which connects kafka as a consumer.
But for foreign insert, it will connects kafka as a producer. So we should also add the kafka configs.